### PR TITLE
Add quotes option

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@ See [action.yml](action.yml)
     format: ''
     # Filter files using a glob filter
     filter: '*'
+    # Wrap output with quotes. Only applies to 'space-delimited' and 'csv' formats.
+    # Can be 'none', 'single', or 'double'.
+    # Default: 'none'
+    quotes: 'none'
 ```
 
 ### Filtering


### PR DESCRIPTION
This adds support for automatically quoting the outputted files. Sometimes, files can contain characters like `()[]` that may interfere with shells, this allows automatic escaping of these during output. I also simplified the formatting process so it's a bit more streamlined.