### PR TITLE
Switch from @zeit/ncc package to @vercel/ncc

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "@types/minimatch": "3.0.4",
     "@types/node": "^14.17.0",
     "@typescript-eslint/parser": "^2.8.0",
-    "@zeit/ncc": "^0.21.0",
+    "@vercel/ncc": "^0.34.0",
     "eslint": "^6.8.0",
     "eslint-plugin-github": "^3.4.0",
     "eslint-plugin-jest": "^23.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -698,10 +698,10 @@
     semver "^6.3.0"
     tsutils "^3.17.1"
 
-"@zeit/ncc@^0.21.0":
-  version "0.21.1"
-  resolved "https://registry.yarnpkg.com/@zeit/ncc/-/ncc-0.21.1.tgz#44fd4359c54ba34a018a5ccf7a315489db20a733"
-  integrity sha512-M9WzgquSOt2nsjRkYM9LRylBLmmlwNCwYbm3Up3PDEshfvdmIfqpFNSK8EJvR18NwZjGHE5z2avlDtYQx2JQnw==
+"@vercel/ncc@^0.34.0":
+  version "0.34.0"
+  resolved "https://registry.yarnpkg.com/@vercel/ncc/-/ncc-0.34.0.tgz#d0139528320e46670d949c82967044a8f66db054"
+  integrity sha512-G9h5ZLBJ/V57Ou9vz5hI8pda/YQX5HQszCs3AmIus3XzsmRn/0Ptic5otD3xVST8QLKk7AMk7AqpsyQGN7MZ9A==
 
 abab@^2.0.0:
   version "2.0.3"


### PR DESCRIPTION
Gets rid of this warning: `@zeit/ncc@0.21.1: @zeit/ncc is no longer maintained. Please use @vercel/ncc instead.`