### PR TITLE
Upgrade to Node 20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -5,7 +5,7 @@ branding:
   icon: file
   color: purple
 runs:
-  using: node16
+  using: node20
   main: dist/index.js
 inputs:
   token:


### PR DESCRIPTION
Given that Node 16 has been EOLd: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/

Closes https://github.com/Ana06/get-changed-files/issues/37