### PR TITLE
Write Output To Files

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -121,3 +121,30 @@ jobs:
           echo 'steps.files-filtered.outputs.added_modified=${{ steps.files-filtered.outputs.added_modified }}'
           echo 'steps.files-filtered.outputs.added_modified_renamed=${{ steps.files-filtered.outputs.added_modified_renamed }}'
 
+      - id: files-written
+        name: Run the action and save to a file
+        uses: ./
+        with:
+          format: 'space-delimited'
+          output-dir: 'out'
+
+      - name: Check files written
+        run: |
+          if ! [ -d out ]; then
+            echo 'Directory not created'
+            exit 1
+          fi
+          ls out
+          
+          if ! [ -f out/all.txt ]; then
+            echo 'Output file not created'
+            exit 1
+          fi
+          
+          content=$(cat out/all.txt)
+          echo $content
+          
+          if [ "$content" != '${{ steps.files-written.outputs.all }}' ]; then
+            echo 'Written content does not match expected'
+            exit 1
+          fi

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ This project is a fork of [jitterbit/get-changed-files](https://github.com/jitte
 - Considers renamed modified files as modified
 - Adds `added_modified_renamed` that includes renamed non-modified files and all files in `added_modified`
 - Removes node12 deprecation warnings
+- Supports writing output to file
 
 ---
 
@@ -27,6 +28,7 @@ This project is a fork of [jitterbit/get-changed-files](https://github.com/jitte
   - [Get all changed `*.yml` files but exclude `.github/*/*.yml` files](#get-all-changed-yml-files-but-exclude-githubyml-files)
   - [Get all added and modified files as CSV](#get-all-added-and-modified-files-as-csv)
   - [Get all removed files as JSON](#get-all-removed-files-as-json)
+  - [Write output to files](#write-output-to-files)
 - [Install, Build, Lint, Test, and Package](#install-build-lint-test-and-package)
 - [License](#license)
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ See [action.yml](action.yml)
     format: ''
     # Filter files using a glob filter
     filter: '*'
+    # Write the output to files in the specified folder
+    output-dir: 'path/to/folder'
 ```
 
 ### Filtering
@@ -127,6 +129,28 @@ If those two globs were inverted, you **would** include all the YML files, with 
       echo "Do something with this ${removed_file}."
     done
 ```
+
+### Write output to files
+You can specify the `output-dir` to have the action write the changed files to the specified directory.
+Each of the normal outputs (all, renamed, removed, etc) will be written to a file with
+the same name as the output and the extension specified by `format` (space-delimited will use .txt).
+
+For example:
+
+```yaml
+- id: files
+  uses: Ana06/get-changed-files@v2.3.0
+  with:
+    format: 'json'
+    output-dir: 'outputs'
+```
+
+Will write the following files:
+- outputs/all.json
+- outputs/renamed.json
+- outputs/removed.json
+- ...
+
 
 ## Install, Build, Lint, Test, and Package
 

--- a/action.yml
+++ b/action.yml
@@ -21,8 +21,13 @@ inputs:
     required: true
     default: space-delimited
   filter:
+    description: Filter files to include in the changes using a glob filter.
     required: true
     default: '*'
+  output-dir:
+    description: Write the changes to files in the specified directory.
+    required: false
+    default: ''
 outputs:
   all:
     description: >


### PR DESCRIPTION
This PR adds an option to allow writing the output directly to a file. This limits issues (quotes, expansions, escapes, etc) when trying to pass the output to another step in a pipeline.

Documentation and tests included. Published a release on my work to allow testing.