### PR TITLE
Add Workflow Dispatch Support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,8 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
+
 
 jobs:
   debug:
@@ -120,4 +122,3 @@ jobs:
           echo 'steps.files-filtered.outputs.renamed=${{ steps.files-filtered.outputs.renamed }}'
           echo 'steps.files-filtered.outputs.added_modified=${{ steps.files-filtered.outputs.added_modified }}'
           echo 'steps.files-filtered.outputs.added_modified_renamed=${{ steps.files-filtered.outputs.added_modified_renamed }}'
-

--- a/README.md
+++ b/README.md
@@ -3,10 +3,13 @@
 [![CI status](https://github.com/Ana06/get-changed-files/workflows/Test/badge.svg)](https://github.com/Ana06/get-changed-files/actions?query=event%3Apush+branch%3Amain)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE.txt)
 
-Get all changed/modified files in a pull request (`pull_request` or `pull_request_target`) or push's commits.
-You can choose to get all changed files, only added files, only modified files, only removed files, only renamed files, or all added and modified files.
+Get all changed/modified files in a pull request (`pull_request` or `pull_request_target`),
+push, or workflow dispatch commits.
+You can choose to get all changed files, only added files, only modified files, only removed files,
+only renamed files, or all added and modified files.
 These outputs are available via the `steps` output context.
-The `steps` output context exposes the output names `all`, `added`, `modified`, `removed`, `renamed`, and `added_modified` and `added_modified_renamed`.
+The `steps` output context exposes the output names `all`, `added`, `modified`,
+`removed`, `renamed`, and `added_modified` and `added_modified_renamed`.
 Renamed files that are also modified are included in `renamed`, `modified` and `added_modified`.
 
 This project is a fork of [jitterbit/get-changed-files](https://github.com/jitterbit/get-changed-files), which:
@@ -16,6 +19,7 @@ This project is a fork of [jitterbit/get-changed-files](https://github.com/jitte
 - Considers renamed modified files as modified
 - Adds `added_modified_renamed` that includes renamed non-modified files and all files in `added_modified`
 - Removes node12 deprecation warnings
+- Adds workflow dispatch support
 
 ---
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -29,6 +29,25 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 const core = __importStar(__nccwpck_require__(2186));
 const github_1 = __nccwpck_require__(5438);
 const minimatch_1 = __importDefault(__nccwpck_require__(3973));
+function getBaseCommit(head, client) {
+    return __awaiter(this, void 0, void 0, function* () {
+        core.debug(`Fetching base commit for ${head}`);
+        const response = yield client.repos.getCommit({
+            owner: github_1.context.repo.owner,
+            repo: github_1.context.repo.repo,
+            ref: head
+        });
+        if (response.status !== 200) {
+            core.setFailed(`The GitHub API for fetching commits for this ${github_1.context.eventName} event returned ${response.status}, expected 200. ` +
+                "Please submit an issue on this action's GitHub repo.");
+        }
+        const parents = response.data.parents;
+        if (parents.length === 0) {
+            core.setFailed(`No parents found for commit ${head}, nothing to compare against!`);
+        }
+        return parents[0].sha;
+    });
+}
 function run() {
     var _a, _b, _c, _d;
     return __awaiter(this, void 0, void 0, function* () {
@@ -58,8 +77,12 @@ function run() {
                     base = github_1.context.payload.before;
                     head = github_1.context.payload.after;
                     break;
+                case 'workflow_dispatch':
+                    head = github_1.context.sha;
+                    base = yield getBaseCommit(head, client);
+                    break;
                 default:
-                    core.setFailed(`This action only supports pull requests and pushes, ${github_1.context.eventName} events are not supported. ` +
+                    core.setFailed(`This action only supports pull requests, pushes, and workflow dispatch, ${github_1.context.eventName} events are not supported. ` +
                         "Please submit an issue on this action's GitHub repo if you believe this in correct.");
             }
             // Log the base and head commits

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,6 +5,29 @@ import minimatch from 'minimatch'
 type Format = 'space-delimited' | 'csv' | 'json'
 type FileStatus = 'added' | 'modified' | 'removed' | 'renamed'
 
+async function getBaseCommit(head: string, client: GitHub): Promise<string> {
+  core.debug(`Fetching base commit for ${head}`)
+  const response = await client.repos.getCommit({
+    owner: context.repo.owner,
+    repo: context.repo.repo,
+    ref: head
+  })
+
+  if (response.status !== 200) {
+    core.setFailed(
+      `The GitHub API for fetching commits for this ${context.eventName} event returned ${response.status}, expected 200. ` +
+        "Please submit an issue on this action's GitHub repo."
+    )
+  }
+
+  const parents = response.data.parents
+  if (parents.length === 0) {
+    core.setFailed(`No parents found for commit ${head}, nothing to compare against!`)
+  }
+
+  return parents[0].sha
+}
+
 async function run(): Promise<void> {
   try {
     // Create GitHub client with the API token.
@@ -37,9 +60,13 @@ async function run(): Promise<void> {
         base = context.payload.before
         head = context.payload.after
         break
+      case 'workflow_dispatch':
+        head = context.sha
+        base = await getBaseCommit(head, client)
+        break
       default:
         core.setFailed(
-          `This action only supports pull requests and pushes, ${context.eventName} events are not supported. ` +
+          `This action only supports pull requests, pushes, and workflow dispatch, ${context.eventName} events are not supported. ` +
             "Please submit an issue on this action's GitHub repo if you believe this in correct."
         )
     }


### PR DESCRIPTION
This PR adds support for workflow dispatches, by reading the head commit from the github context, fetching that commit from the API, and using the returned parents to get the head. Here's a sample run:

https://github.com/HassanAbouelela/get-changed-files/actions/runs/13874763242/job/38825681318#step:3:24