### PR TITLE
Node.js 24 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,11 +52,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
 
       - name: Install dependencies
         run: |
@@ -83,7 +83,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - id: files
         uses: ./

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ This project is a fork of [jitterbit/get-changed-files](https://github.com/jitte
 See [action.yml](action.yml)
 
 ```yaml
-- uses: Ana06/get-changed-files@v2.3.0
+- uses: Ana06/get-changed-files@v2.4.0
   with:
     # Format of the steps output context.
     # Can be 'space-delimited', 'csv', or 'json'.
@@ -61,7 +61,7 @@ Consider using one of the other formats if that's the case.
 
 ```yaml
 - id: files
-  uses: Ana06/get-changed-files@v2.3.0
+  uses: Ana06/get-changed-files@v2.4.0
 - run: |
     for changed_file in ${{ steps.files.outputs.all }}; do
       echo "Do something with this ${changed_file}."
@@ -75,7 +75,7 @@ Consider using one of the other formats if that's the case.
 
 ```yaml
 - id: files
-  uses: Ana06/get-changed-files@v2.3.0
+  uses: Ana06/get-changed-files@v2.4.0
   with:
     filter: '*.php'
 - run: |
@@ -91,7 +91,7 @@ Therefore, including all YML files first and excluding the YML files of your `.g
 If those two globs were inverted, you **would** include all the YML files, with the ones in your `.github/*/` directories.
 
 ```yaml
-- uses: Ana06/get-changed-files@v2.3.0
+- uses: Ana06/get-changed-files@v2.4.0
   with:
     filter: |
       *.yml
@@ -102,7 +102,7 @@ If those two globs were inverted, you **would** include all the YML files, with 
 
 ```yaml
 - id: files
-  uses: Ana06/get-changed-files@v2.3.0
+  uses: Ana06/get-changed-files@v2.4.0
   with:
     format: 'csv'
     filter: '*'
@@ -117,7 +117,7 @@ If those two globs were inverted, you **would** include all the YML files, with 
 
 ```yaml
 - id: files
-  uses: Ana06/get-changed-files@v2.3.0
+  uses: Ana06/get-changed-files@v2.4.0
   with:
     format: 'json'
     filter: '*'
@@ -135,6 +135,12 @@ Make sure to do the following before checking in any code changes.
 ```bash
 yarn
 yarn all
+```
+
+To update dist/index.js
+
+```bash
+yarn && rm -rf dist/ && yarn all
 ```
 
 ## License

--- a/action.yml
+++ b/action.yml
@@ -5,7 +5,7 @@ branding:
   icon: file
   color: purple
 runs:
-  using: node20
+  using: node24
   main: dist/index.js
 inputs:
   token:

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "get-changed-files",
   "description": "GitHub action that gets all changed files in a pull request or push.",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "private": true,
   "author": "Jitterbit, Inc.",
   "license": "MIT",
@@ -26,7 +26,7 @@
   ],
   "main": "lib/main.js",
   "engines": {
-    "node": "^20"
+    "node": "^24"
   },
   "scripts": {
     "build": "tsc",


### PR DESCRIPTION
This pull request updates the project to version 2.4.0, primarily upgrading the Node.js runtime from version 20 to 24 and updating documentation and usage examples to reflect the new version. It also adds instructions for rebuilding the distribution file.

**Version and Runtime Updates:**

* Bumped the project version from `2.3.0` to `2.4.0` in `package.json` and updated all usage examples in `README.md` to use `@v2.4.0` instead of `@v2.3.0`. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L4-R4) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L38-R38) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L64-R64) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L78-R78) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L94-R94) [[6]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L105-R105) [[7]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L120-R120)
* Updated the Node.js engine requirement from `^20` to `^24` in both `package.json` and `action.yml`, ensuring the action runs on the latest supported Node.js version. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L29-R29) [[2]](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6L8-R8)

**Documentation Improvements:**

* Added a section to `README.md` with instructions on how to rebuild `dist/index.js` using `ncc`.

PR description created with CoPilot, but the code itself was updated by me.